### PR TITLE
Add DuckDuckGo search provider

### DIFF
--- a/web-search.el
+++ b/web-search.el
@@ -52,6 +52,7 @@
     ("Bing"              "https://www.bing.com/search?q=%s" "Search")
     ("Debian Manpages"   "https://manpages.debian.org/jump?q=%s")
     ("Debian Package"    "https://packages.debian.org/search?keywords=%s&searchon=names&suite=stable&section=all")
+    ("DuckDuckGo"        "https://duckduckgo.com/lite/?q=%s" "Search")
     ("Gist"              "https://gist.github.com/search?q=%s" "Code")
     ("GitHub"            "https://github.com/search?q=%s" "Code")
     ("Google"            "https://www.google.com/search?q=%s" "Search")


### PR DESCRIPTION
I found your web search melpa package just today, and looking at the list of providers, noticed that DuckDuckGo, a privacy-friendly search engine, was missing, so I thought I'd add it myself. Using the regular search link for DDG (which I found in my browser's preferences) brought me to a notice that the results were going to redirect to a non-javascript version of the site, so I thought I'd add that one instead, as to not have that delay. [From this page](https://duck.co/help/features/non-javascript), I saw that there are 2 non-javascript versions, one html version and one lite version. I tried both, and lite worked the best for me, especially as it had the best presentation on eww. Feel free to test my addition as much as you want. Thanks in advance.
P.S. I Implemented this change only in the .el file, since I lack knowledge on Bash scripting. Hopefully the link used in the .el version can easily be translated to the bash script version.